### PR TITLE
Avoid duplicate base_link to base_laser transform

### DIFF
--- a/src/ldlidar_stl_ros2-3.0.3/launch/ld06.launch.py
+++ b/src/ldlidar_stl_ros2-3.0.3/launch/ld06.launch.py
@@ -1,59 +1,54 @@
 #!/usr/bin/env python3
+
+"""
+Launch file for the LD06 LiDAR.
+
+The static transform between ``base_link`` and ``base_laser`` can be disabled
+using the ``publish_tf`` launch argument.  This avoids conflicts when another
+launch file publishes the same transform.
+"""
+
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.conditions import IfCondition
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
-'''
-Parameter Description:
----
-- Set laser scan directon: 
-  1. Set counterclockwise, example: {'laser_scan_dir': True}
-  2. Set clockwise,        example: {'laser_scan_dir': False}
-- Angle crop setting, Mask data within the set angle range:
-  1. Enable angle crop fuction:
-    1.1. enable angle crop,  example: {'enable_angle_crop_func': True}
-    1.2. disable angle crop, example: {'enable_angle_crop_func': False}
-  2. Angle cropping interval setting:
-  - The distance and intensity data within the set angle range will be set to 0.
-  - angle >= 'angle_crop_min' and angle <= 'angle_crop_max' which is [angle_crop_min, angle_crop_max], unit is degress.
-    example:
-      {'angle_crop_min': 135.0}
-      {'angle_crop_max': 225.0}
-      which is [135.0, 225.0], angle unit is degress.
-'''
 
 def generate_launch_description():
-  # LDROBOT LiDAR publisher node
-  ldlidar_node = Node(
-      package='ldlidar_stl_ros2',
-      executable='ldlidar_stl_ros2_node',
-      name='LD06',
-      output='screen',
-      parameters=[
-        {'product_name': 'LDLiDAR_LD06'},
-        {'topic_name': 'scan'},
-        {'frame_id': 'base_laser'},
-        {'port_name': '/dev/ttyUSB0'},
-        {'port_baudrate': 230400},
-        {'laser_scan_dir': True},
-        {'enable_angle_crop_func': False},
-        {'angle_crop_min': 135.0},
-        {'angle_crop_max': 225.0}
-      ]
-  )
+    publish_tf = LaunchConfiguration("publish_tf")
 
-  # base_link to base_laser tf node
-  base_link_to_laser_tf_node = Node(
-    package='tf2_ros',
-    executable='static_transform_publisher',
-    name='base_link_to_base_laser_ld06',
-    arguments=['0','0','0.18','0','0','0','base_link','base_laser']
-  )
+    ldlidar_node = Node(
+        package="ldlidar_stl_ros2",
+        executable="ldlidar_stl_ros2_node",
+        name="LD06",
+        output="screen",
+        parameters=[
+            {"product_name": "LDLiDAR_LD06"},
+            {"topic_name": "scan"},
+            {"frame_id": "base_laser"},
+            {"port_name": "/dev/ttyUSB0"},
+            {"port_baudrate": 230400},
+            {"laser_scan_dir": True},
+            {"enable_angle_crop_func": False},
+            {"angle_crop_min": 135.0},
+            {"angle_crop_max": 225.0},
+        ],
+    )
 
+    base_link_to_laser_tf_node = Node(
+        package="tf2_ros",
+        executable="static_transform_publisher",
+        name="base_link_to_base_laser_ld06",
+        arguments=["0", "0", "0.18", "0", "0", "0", "base_link", "base_laser"],
+        condition=IfCondition(publish_tf),
+    )
 
-  # Define LaunchDescription variable
-  ld = LaunchDescription()
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument("publish_tf", default_value="true"),
+            ldlidar_node,
+            base_link_to_laser_tf_node,
+        ]
+    )
 
-  ld.add_action(ldlidar_node)
-  ld.add_action(base_link_to_laser_tf_node)
-
-  return ld

--- a/src/ldlidar_stl_ros2-3.0.3/launch/ld19.launch.py
+++ b/src/ldlidar_stl_ros2-3.0.3/launch/ld19.launch.py
@@ -1,59 +1,56 @@
 #!/usr/bin/env python3
+
+"""
+Launch file for the LD19 LiDAR.
+
+The node optionally publishes a static transform between ``base_link`` and
+``base_laser``.  Set the ``publish_tf`` launch argument to ``false`` when the
+transform is provided elsewhere (e.g. in an external bringup launch file).
+"""
+
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.conditions import IfCondition
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
-'''
-Parameter Description:
----
-- Set laser scan directon: 
-  1. Set counterclockwise, example: {'laser_scan_dir': True}
-  2. Set clockwise,        example: {'laser_scan_dir': False}
-- Angle crop setting, Mask data within the set angle range:
-  1. Enable angle crop fuction:
-    1.1. enable angle crop,  example: {'enable_angle_crop_func': True}
-    1.2. disable angle crop, example: {'enable_angle_crop_func': False}
-  2. Angle cropping interval setting:
-  - The distance and intensity data within the set angle range will be set to 0.
-  - angle >= 'angle_crop_min' and angle <= 'angle_crop_max' which is [angle_crop_min, angle_crop_max], unit is degress.
-    example:
-      {'angle_crop_min': 135.0}
-      {'angle_crop_max': 225.0}
-      which is [135.0, 225.0], angle unit is degress.
-'''
 
 def generate_launch_description():
-  # LDROBOT LiDAR publisher node
-  ldlidar_node = Node(
-      package='ldlidar_stl_ros2',
-      executable='ldlidar_stl_ros2_node',
-      name='LD19',
-      output='screen',
-      parameters=[
-        {'product_name': 'LDLiDAR_LD19'},
-        {'topic_name': 'scan'},
-        {'frame_id': 'base_laser'},
-        {'port_name': '/dev/ttyUSB0'},
-        {'port_baudrate': 230400},
-        {'laser_scan_dir': True},
-        {'enable_angle_crop_func': False},
-        {'angle_crop_min': 135.0},
-        {'angle_crop_max': 225.0}
-      ]
-  )
+    publish_tf = LaunchConfiguration("publish_tf")
 
-  # base_link to base_laser tf node
-  base_link_to_laser_tf_node = Node(
-    package='tf2_ros',
-    executable='static_transform_publisher',
-    name='base_link_to_base_laser_ld19',
-    arguments=['0','0','0.18','0','0','0','base_link','base_laser']
-  )
+    # LDROBOT LiDAR publisher node
+    ldlidar_node = Node(
+        package="ldlidar_stl_ros2",
+        executable="ldlidar_stl_ros2_node",
+        name="LD19",
+        output="screen",
+        parameters=[
+            {"product_name": "LDLiDAR_LD19"},
+            {"topic_name": "scan"},
+            {"frame_id": "base_laser"},
+            {"port_name": "/dev/ttyUSB0"},
+            {"port_baudrate": 230400},
+            {"laser_scan_dir": True},
+            {"enable_angle_crop_func": False},
+            {"angle_crop_min": 135.0},
+            {"angle_crop_max": 225.0},
+        ],
+    )
 
+    # Optional base_link to base_laser static transform
+    base_link_to_laser_tf_node = Node(
+        package="tf2_ros",
+        executable="static_transform_publisher",
+        name="base_link_to_base_laser_ld19",
+        arguments=["0", "0", "0.18", "0", "0", "0", "base_link", "base_laser"],
+        condition=IfCondition(publish_tf),
+    )
 
-  # Define LaunchDescription variable
-  ld = LaunchDescription()
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument("publish_tf", default_value="true"),
+            ldlidar_node,
+            base_link_to_laser_tf_node,
+        ]
+    )
 
-  ld.add_action(ldlidar_node)
-  ld.add_action(base_link_to_laser_tf_node)
-
-  return ld

--- a/src/robot_base/launch/bringup_all.launch.py
+++ b/src/robot_base/launch/bringup_all.launch.py
@@ -87,7 +87,8 @@ def generate_launch_description():
     lidar_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(get_package_share_directory('ldlidar_stl_ros2'), 'launch', 'ld19.launch.py')
-        )
+        ),
+        launch_arguments={'publish_tf': 'false'}.items()
     )
 
     static_laser_tf = Node(


### PR DESCRIPTION
## Summary
- make lidar static transform optional in ldlidar launch files
- disable ldlidar static TF in bringup to prevent duplicate base_link→base_laser transforms

## Testing
- `python -m py_compile src/ldlidar_stl_ros2-3.0.3/launch/ld19.launch.py src/ldlidar_stl_ros2-3.0.3/launch/ld06.launch.py src/robot_base/launch/bringup_all.launch.py`
- `colcon test --packages-select robot_base ldlidar_stl_ros2` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_68b8988d7d088331b85008fb91a17a7a