### PR TITLE
Eliminate duplicate laser TFs

### DIFF
--- a/src/ldlidar_stl_ros2-3.0.3/launch/ld19.launch.py
+++ b/src/ldlidar_stl_ros2-3.0.3/launch/ld19.launch.py
@@ -4,8 +4,8 @@
 Launch file for the LD19 LiDAR.
 
 The node optionally publishes a static transform between ``base_link`` and
-``base_laser``.  Set the ``publish_tf`` launch argument to ``false`` when the
-transform is provided elsewhere (e.g. in an external bringup launch file).
+``base_laser``.  Set the ``publish_tf`` launch argument to ``true`` when the
+transform is not provided elsewhere (e.g. in an external bringup launch file).
 """
 
 from launch import LaunchDescription
@@ -48,7 +48,7 @@ def generate_launch_description():
 
     return LaunchDescription(
         [
-            DeclareLaunchArgument("publish_tf", default_value="true"),
+            DeclareLaunchArgument("publish_tf", default_value="false"),
             ldlidar_node,
             base_link_to_laser_tf_node,
         ]

--- a/src/robot_base/launch/static_tf.launch.py
+++ b/src/robot_base/launch/static_tf.launch.py
@@ -9,7 +9,7 @@ def generate_launch_description():
             package='tf2_ros',
             executable='static_transform_publisher',
             name='base_to_laser_tf',
-            arguments=['0.0', '0.0', '0.18', '0.0', '0.0', '0.0', 'base_link', 'laser']
+            arguments=['0.0', '0.0', '0.18', '0.0', '0.0', '0.0', 'base_link', 'base_laser']
         )
     ])
 


### PR DESCRIPTION
## Summary
- Use `base_laser` frame in static laser TF
- Disable LD19 launch's TF publishing by default to avoid duplicates

## Testing
- `ros2 run tf2_tools view_frames` *(failed: `ros2` not found)*
- `apt-get update` *(failed: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ce27ddbc8331ad1cfee0a7cb7540